### PR TITLE
Improve performance of symbol resolution + code cleanup

### DIFF
--- a/Engine/DiaUtil.cs
+++ b/Engine/DiaUtil.cs
@@ -30,61 +30,46 @@
 //    to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.
 //</copyright>
 //------------------------------------------------------------------------------
+
 namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
 {
+    using Dia;
     using System;
+    using System.Runtime.InteropServices;
 
-    class Program
+    /// <summary>
+    /// Wrapper class around DIA
+    /// </summary>
+    public class DiaUtil
     {
-        static void Main(string[] args)
+        public IDiaDataSource _IDiaDataSource;
+        public IDiaSession _IDiaSession;
+        private bool disposedValue = false;
+
+        public DiaUtil(string pdbName)
         {
-            if (!TestBlockResolution())
-                Console.WriteLine("FAIL: TestBlockResolution");
-            else
-                Console.WriteLine("PASS: TestBlockResolution");
-
-            if (!TestOrdinal())
-                Console.WriteLine("FAIL: TestOrdinal");
-            else
-                Console.WriteLine("PASS: TestOrdinal");
-
+            _IDiaDataSource = new DiaSource();
+            _IDiaDataSource.loadDataFromPdb(pdbName);
+            _IDiaDataSource.openSession(out _IDiaSession);
         }
 
-        private static bool TestBlockResolution()
+        public void Dispose()
         {
-            var csr = new StackResolver();
-            var ret = csr.ResolveCallstacks("Return Addr: 00007FF830D4CDA4 Module(KERNELBASE+000000000009CDA4)",
-                @"..\..\Tests\TestCases\TestBlockResolution",
-                false,
-                null,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "KERNELBASE!SignalObjectAndWait+147716";
+            this.Dispose(true);
         }
 
-        private static bool TestOrdinal()
+        protected virtual void Dispose(bool disposing)
         {
-            var csr = new StackResolver();
-            var dllPaths = new System.Collections.Generic.List<string>();
-            dllPaths.Add(@"..\..\Tests\TestCases\TestOrdinal");
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    Marshal.FinalReleaseComObject(_IDiaSession);
+                    Marshal.FinalReleaseComObject(_IDiaDataSource);
+                }
 
-            var ret = csr.ResolveCallstacks("sqldk!Ordinal298+00000000000004A5",
-                @"..\..\Tests\TestCases\TestOrdinal",
-                false,
-                dllPaths,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "sqldk!SOS_Scheduler::SwitchContext+941";
+                disposedValue = true;
+            }
         }
     }
 }

--- a/Engine/ExportedSymbol.cs
+++ b/Engine/ExportedSymbol.cs
@@ -30,61 +30,15 @@
 //    to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.
 //</copyright>
 //------------------------------------------------------------------------------
+
 namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
 {
-    using System;
-
-    class Program
+    /// <summary>
+    /// Helper class which stores DLL export name and address (offset)
+    /// </summary>
+    public class ExportedSymbol
     {
-        static void Main(string[] args)
-        {
-            if (!TestBlockResolution())
-                Console.WriteLine("FAIL: TestBlockResolution");
-            else
-                Console.WriteLine("PASS: TestBlockResolution");
-
-            if (!TestOrdinal())
-                Console.WriteLine("FAIL: TestOrdinal");
-            else
-                Console.WriteLine("PASS: TestOrdinal");
-
-        }
-
-        private static bool TestBlockResolution()
-        {
-            var csr = new StackResolver();
-            var ret = csr.ResolveCallstacks("Return Addr: 00007FF830D4CDA4 Module(KERNELBASE+000000000009CDA4)",
-                @"..\..\Tests\TestCases\TestBlockResolution",
-                false,
-                null,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "KERNELBASE!SignalObjectAndWait+147716";
-        }
-
-        private static bool TestOrdinal()
-        {
-            var csr = new StackResolver();
-            var dllPaths = new System.Collections.Generic.List<string>();
-            dllPaths.Add(@"..\..\Tests\TestCases\TestOrdinal");
-
-            var ret = csr.ResolveCallstacks("sqldk!Ordinal298+00000000000004A5",
-                @"..\..\Tests\TestCases\TestOrdinal",
-                false,
-                dllPaths,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "sqldk!SOS_Scheduler::SwitchContext+941";
-        }
+        public string Name { get; set; }
+        public uint Address { get; set; }
     }
 }

--- a/Engine/IMAGE_EXPORT_DIRECTORY.cs
+++ b/Engine/IMAGE_EXPORT_DIRECTORY.cs
@@ -30,61 +30,27 @@
 //    to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.
 //</copyright>
 //------------------------------------------------------------------------------
+
 namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
 {
-    using System;
+    using System.Runtime.InteropServices;
 
-    class Program
+    /// <summary>
+    /// PE header's Image Export Directory
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct IMAGE_EXPORT_DIRECTORY
     {
-        static void Main(string[] args)
-        {
-            if (!TestBlockResolution())
-                Console.WriteLine("FAIL: TestBlockResolution");
-            else
-                Console.WriteLine("PASS: TestBlockResolution");
-
-            if (!TestOrdinal())
-                Console.WriteLine("FAIL: TestOrdinal");
-            else
-                Console.WriteLine("PASS: TestOrdinal");
-
-        }
-
-        private static bool TestBlockResolution()
-        {
-            var csr = new StackResolver();
-            var ret = csr.ResolveCallstacks("Return Addr: 00007FF830D4CDA4 Module(KERNELBASE+000000000009CDA4)",
-                @"..\..\Tests\TestCases\TestBlockResolution",
-                false,
-                null,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "KERNELBASE!SignalObjectAndWait+147716";
-        }
-
-        private static bool TestOrdinal()
-        {
-            var csr = new StackResolver();
-            var dllPaths = new System.Collections.Generic.List<string>();
-            dllPaths.Add(@"..\..\Tests\TestCases\TestOrdinal");
-
-            var ret = csr.ResolveCallstacks("sqldk!Ordinal298+00000000000004A5",
-                @"..\..\Tests\TestCases\TestOrdinal",
-                false,
-                dllPaths,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "sqldk!SOS_Scheduler::SwitchContext+941";
-        }
+        public uint Characteristics;
+        public uint TimeDateStamp;
+        public ushort MajorVersion;
+        public ushort MinorVersion;
+        public int Name;
+        public int Base;
+        public int NumberOfFunctions;
+        public int NumberOfNames;
+        public int AddressOfFunctions;
+        public int AddressOfNames;    
+        public int AddressOfOrdinals;                                 
     }
 }

--- a/Engine/ModuleInfo.cs
+++ b/Engine/ModuleInfo.cs
@@ -30,61 +30,21 @@
 //    to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.
 //</copyright>
 //------------------------------------------------------------------------------
+
 namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
 {
-    using System;
-
-    class Program
+    /// <summary>
+    /// Helper class to store module name, start and end address
+    /// </summary>
+    class ModuleInfo
     {
-        static void Main(string[] args)
+        public string ModuleName;
+        public ulong BaseAddress;
+        public ulong EndAddress;
+
+        public override string ToString()
         {
-            if (!TestBlockResolution())
-                Console.WriteLine("FAIL: TestBlockResolution");
-            else
-                Console.WriteLine("PASS: TestBlockResolution");
-
-            if (!TestOrdinal())
-                Console.WriteLine("FAIL: TestOrdinal");
-            else
-                Console.WriteLine("PASS: TestOrdinal");
-
-        }
-
-        private static bool TestBlockResolution()
-        {
-            var csr = new StackResolver();
-            var ret = csr.ResolveCallstacks("Return Addr: 00007FF830D4CDA4 Module(KERNELBASE+000000000009CDA4)",
-                @"..\..\Tests\TestCases\TestBlockResolution",
-                false,
-                null,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "KERNELBASE!SignalObjectAndWait+147716";
-        }
-
-        private static bool TestOrdinal()
-        {
-            var csr = new StackResolver();
-            var dllPaths = new System.Collections.Generic.List<string>();
-            dllPaths.Add(@"..\..\Tests\TestCases\TestOrdinal");
-
-            var ret = csr.ResolveCallstacks("sqldk!Ordinal298+00000000000004A5",
-                @"..\..\Tests\TestCases\TestOrdinal",
-                false,
-                dllPaths,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "sqldk!SOS_Scheduler::SwitchContext+941";
+            return string.Format("{0} from {1:X} to {2:X}", ModuleName, BaseAddress, EndAddress);
         }
     }
 }

--- a/Engine/SQLCallStackResolver.Engine.csproj
+++ b/Engine/SQLCallStackResolver.Engine.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Target\Debug\</OutputPath>
-<BaseIntermediateOutputPath>..\Target\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>..\Target\</BaseIntermediateOutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Target\Release\</OutputPath>
-<BaseIntermediateOutputPath>..\Target\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>..\Target\</BaseIntermediateOutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -108,8 +108,14 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DiaUtil.cs" />
+    <Compile Include="ExportedSymbol.cs" />
+    <Compile Include="IMAGE_EXPORT_DIRECTORY.cs" />
+    <Compile Include="ModuleInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StackResolver.cs" />
+    <Compile Include="StackWithCount.cs" />
+    <Compile Include="ThreadParams.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
     using System.Threading.Tasks;
     using System.Xml;
 
-    public class StackResolver
+    public class StackResolver : IDisposable
     {
         /// <summary>
         /// This is used to store module name and start / end virtual address ranges
@@ -63,6 +63,16 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
         /// Only populated if the user provides the 'image path' to the DLLs
         /// </summary>
         Dictionary<string, Dictionary<int, ExportedSymbol>> _DLLOrdinalMap;
+
+        /// <summary>
+        /// A cache of already resolved addresses
+        /// </summary>
+        Dictionary<string, string> cachedSymbols = new Dictionary<string, string>();
+
+        /// <summary>
+        /// R/W lock to protect the above cached symbols dictionary
+        /// </summary>
+        ReaderWriterLockSlim rwLockCachedSymbols = new ReaderWriterLockSlim();
 
         /// <summary>
         /// This function loads DLLs from a specified path, so that we can then build the DLL export's ordinal / address map
@@ -548,6 +558,21 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
 
             // the offsets in the XE output are in hex, so we convert to base-10 accordingly
             var rva = Convert.ToUInt32(offset, 16);
+            var symKey = moduleName + rva.ToString();
+
+            string result = null;
+            this.rwLockCachedSymbols.EnterReadLock();
+            if (this.cachedSymbols.ContainsKey(symKey))
+            {
+                result = this.cachedSymbols[symKey];
+            }
+            this.rwLockCachedSymbols.ExitReadLock();
+
+            if (!string.IsNullOrEmpty(result))
+            {
+                // value was in cache
+                return result;
+            }
 
             // process the function name (symbol)
             // initially we look for 'block' symbols, which have a parent function
@@ -644,9 +669,18 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
             }
 
             // make sure we cleanup COM allocations for the resolved sym
-            Marshal.ReleaseComObject(mysym);
+            Marshal.FinalReleaseComObject(mysym);
 
-            return string.Format("{0}!{1}{2}\t{3}", moduleName, funcname2, offsetStr, sourceInfo).Trim();
+            result = string.Format("{0}!{1}{2}\t{3}", moduleName, funcname2, offsetStr, sourceInfo).Trim();
+
+            this.rwLockCachedSymbols.EnterWriteLock();
+            if (!this.cachedSymbols.ContainsKey(symKey))
+            {
+                this.cachedSymbols.Add(symKey, result);
+            }
+            this.rwLockCachedSymbols.ExitWriteLock();
+
+            return result;
         }
 
         /// <summary>
@@ -716,7 +750,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
         /// <param name="rootPaths"></param>
         /// <param name="recurse"></param>
         /// <param name="moduleNames"></param>
-        private void LocateandLoadPDBs(Dictionary<string, DiaUtil> _diautils, string rootPaths, bool recurse, List<string> moduleNames)
+        private void LocateandLoadPDBs(Dictionary<string, DiaUtil> _diautils, string rootPaths, bool recurse, List<string> moduleNames, bool cachePDB)
         {
             // loop through each module, trying to find matched PDB files
             var splitRootPaths = rootPaths.Split(';');
@@ -724,17 +758,38 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
             {
                 if (!_diautils.ContainsKey(currentModule))
                 {
-                    foreach (var currPath in splitRootPaths)
+                    // check if the PDB is already cached locally
+                    var cachedPDBFile = Path.Combine(Path.GetTempPath(), "SymCache", currentModule + ".pdb");
+                    lock (this)
                     {
-                        if (Directory.Exists(currPath))
+                        if (!File.Exists(cachedPDBFile))
                         {
-                            var foundFiles = Directory.EnumerateFiles(currPath, currentModule + ".pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
-                            if (foundFiles.Count() > 0)
+                            foreach (var currPath in splitRootPaths)
                             {
-                                _diautils.Add(currentModule, new DiaUtil(foundFiles.First()));
-                                break;
+                                if (Directory.Exists(currPath))
+                                {
+                                    var foundFiles = Directory.EnumerateFiles(currPath, currentModule + ".pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+                                    if (foundFiles.Count() > 0)
+                                    {
+                                        if (cachePDB)
+                                        {
+                                            File.Copy(foundFiles.First(), cachedPDBFile);
+                                        }
+                                        else
+                                        {
+                                            cachedPDBFile = foundFiles.First();
+                                        }
+
+                                        break;
+                                    }
+                                }
                             }
                         }
+                    }
+
+                    if (File.Exists(cachedPDBFile))
+                    {
+                        _diautils.Add(currentModule, new DiaUtil(cachedPDBFile));
                     }
                 }
             }
@@ -761,8 +816,24 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
             bool framesOnSingleLine, 
             bool includeSourceInfo,
             bool relookupSource,
-            bool includeOffsets)
+            bool includeOffsets,
+            bool cachePDB)
         {
+            this.cachedSymbols.Clear();
+
+            // delete and recreate the cached PDB folder
+            var symCacheFolder = Path.Combine(Path.GetTempPath(), "SymCache");
+            if (Directory.Exists(symCacheFolder))
+            {
+                new DirectoryInfo(symCacheFolder).GetFiles("*", SearchOption.AllDirectories)
+                    .ToList()
+                    .ForEach(file => file.Delete());
+            }
+            else
+            {
+                Directory.CreateDirectory(symCacheFolder);
+            }
+
             var finalCallstack = new StringBuilder();
             var xmldoc = new XmlDocument();
             bool isXMLdoc = false;
@@ -842,48 +913,34 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
                 }
             }
 
-            // we loop through the list of call stacks to be processed in parallel
-            Parallel.ForEach(listOfCallStacks, currstack =>
+            // Create a pool of threads to process in parallel
+            int numThreads = Math.Min(listOfCallStacks.Count, Environment.ProcessorCount);
+            List<Thread> threads = new List<Thread>();
+            for (int threadOrdinal = 0; threadOrdinal < numThreads; threadOrdinal++)
             {
-                Dictionary<string, DiaUtil> _diautils = new Dictionary<string, DiaUtil>();
-
-                // split the callstack into lines, and for each line try to resolve
-                string ordinalresolvedstack;
-
-                lock (this)
+                var tmpThread = new Thread(ProcessCallStack);
+                threads.Add(tmpThread);
+                tmpThread.Start(new ThreadParams()
                 {
-                    ordinalresolvedstack = LoadDllsIfApplicable(currstack.Callstack, searchDLLRecursively, dllPaths);
-                }
+                    dllPaths = dllPaths,
+                    framesOnSingleLine = framesOnSingleLine,
+                    includeOffsets = includeOffsets,
+                    includeSourceInfo = includeSourceInfo,
+                    listOfCallStacks = listOfCallStacks,
+                    numThreads = numThreads,
+                    relookupSource = relookupSource,
+                    searchDLLRecursively = searchDLLRecursively,
+                    searchPDBsRecursively = searchPDBsRecursively,
+                    symPath = symPath,
+                    threadOrdinal = threadOrdinal,
+                    cachePDB = cachePDB
+                });
+            }
 
-                // sometimes we see call stacks which are arranged horizontally (this typically is seen in Excel or custom reporting tools)
-                // in that case, space is a valid delimiter, and we need to support that as an option
-                var delims = framesOnSingleLine ? new char[2] { ' ', '\n' } : new char[1] { '\n' };
-
-                var callStackLines = ordinalresolvedstack.Replace('\r', ' ').Split(delims, StringSplitOptions.RemoveEmptyEntries);
-
-                // process any frames which are purely virtual address (in such cases, the caller should have specified base addresses)
-                callStackLines = PreProcessVAs(callStackLines);
-
-                // locate the PDBs and populate their DIA session helper classes
-                LocateandLoadPDBs(_diautils, symPath, searchPDBsRecursively, EnumModuleNames(callStackLines));
-
-                // resolve symbols by using DIA
-                currstack.Resolvedstack = ResolveSymbols(_diautils, 
-                    callStackLines, 
-                    includeSourceInfo,
-                    relookupSource,
-                    includeOffsets);
-
-                // cleanup any older COM objects
-                if (_diautils != null)
-                {
-                    foreach (var diautil in _diautils.Values)
-                    {
-                        Marshal.ReleaseComObject(diautil._IDiaDataSource);
-                        Marshal.ReleaseComObject(diautil._IDiaSession);
-                    }
-                }
-            });
+            foreach (var tmpThread in threads)
+            {
+                tmpThread.Join();
+            }
 
             // populate the output
             foreach (var currstack in listOfCallStacks)
@@ -891,7 +948,75 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
                 finalCallstack.AppendLine(currstack.Resolvedstack);
             }
 
+            // Unfortunately the below is necessary to ensure that the handles to the cached PDB files opened by DIA 
+            // and later deleted at the next invocation of this function, are released deterministically
+            // This is despite we correctly releasing those interface pointers using Marshal.FinalReleaseComObject
+            // Thankfully we only need to resort to this if the caller wants to cache PDBs in the temp folder
+            if (cachePDB)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
             return finalCallstack.ToString();
+        }
+
+        /// <summary>
+        /// Function executed by worker threads to process callstacks.
+        /// Threads work on portions of the listOfCallStacks based on their thread ordinal.
+        /// </summary>
+        /// <param name="obj"></param>
+        private void ProcessCallStack(Object obj)
+        {
+            var tp = (ThreadParams)obj;
+
+            Dictionary<string, DiaUtil> _diautils = new Dictionary<string, DiaUtil>();
+
+            for (int tmpStackIndex = 0; tmpStackIndex < tp.listOfCallStacks.Count; tmpStackIndex++)
+            {
+                if (tmpStackIndex % tp.numThreads != tp.threadOrdinal)
+                {
+                    continue;
+                }
+
+                var currstack = tp.listOfCallStacks[tmpStackIndex];
+
+                // split the callstack into lines, and for each line try to resolve
+                string ordinalresolvedstack;
+
+                lock (this)
+                {
+                    ordinalresolvedstack = LoadDllsIfApplicable(currstack.Callstack, tp.searchDLLRecursively, tp.dllPaths);
+                }
+
+                // sometimes we see call stacks which are arranged horizontally (this typically is seen in Excel or custom reporting tools)
+                // in that case, space is a valid delimiter, and we need to support that as an option
+                var delims = tp.framesOnSingleLine ? new char[2] { ' ', '\n' } : new char[1] { '\n' };
+
+                var callStackLines = ordinalresolvedstack.Replace('\r', ' ').Split(delims, StringSplitOptions.RemoveEmptyEntries);
+
+                // process any frames which are purely virtual address (in such cases, the caller should have specified base addresses)
+                callStackLines = PreProcessVAs(callStackLines);
+
+                // locate the PDBs and populate their DIA session helper classes
+                LocateandLoadPDBs(_diautils, tp.symPath, tp.searchPDBsRecursively, EnumModuleNames(callStackLines), tp.cachePDB);
+
+                // resolve symbols by using DIA
+                currstack.Resolvedstack = ResolveSymbols(_diautils,
+                    callStackLines,
+                    tp.includeSourceInfo,
+                    tp.relookupSource,
+                    tp.includeOffsets);
+            }
+
+            // cleanup any older COM objects
+            if (_diautils != null)
+            {
+                foreach (var diautil in _diautils.Values)
+                {
+                    diautil.Dispose();
+                }
+            }
         }
 
         /// <summary>
@@ -933,104 +1058,43 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
 
                 if (!string.IsNullOrEmpty(finalFilePath))
                 {
-                    using (var dllFileStream = new FileStream(finalFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                    using (var dllFile = new PEFile(new FileStream(finalFilePath, FileMode.Open, FileAccess.Read, FileShare.Read), false))
                     {
-                        using (var dllFile = new PEFile(dllFileStream, false))
-                        {
-                            dllFile.GetPdbSignature(out string pdbName, out Guid pdbGuid, out int pdbAge);
+                        dllFile.GetPdbSignature(out string pdbName, out Guid pdbGuid, out int pdbAge);
 
-                            pdbName = System.IO.Path.GetFileNameWithoutExtension(pdbName);
+                        pdbName = System.IO.Path.GetFileNameWithoutExtension(pdbName);
 
-                            var signaturePlusAge = pdbGuid.ToString("N") + pdbAge.ToString();
-                            var fileVersion = dllFile.GetFileVersionInfo().FileVersion;
+                        var signaturePlusAge = pdbGuid.ToString("N") + pdbAge.ToString();
+                        var fileVersion = dllFile.GetFileVersionInfo().FileVersion;
 
-                            finalCommand.Append("\t");
-                            finalCommand.AppendFormat(@"Invoke-WebRequest -uri 'https://msdl.microsoft.com/download/symbols/{0}.pdb/{1}/{0}.pdb' -OutFile '<somepath>\{0}.pdb' # File version {2}", pdbName, signaturePlusAge, fileVersion);
-                            finalCommand.AppendLine();
-                        }
+                        finalCommand.Append("\t");
+                        finalCommand.AppendFormat(@"Invoke-WebRequest -uri 'https://msdl.microsoft.com/download/symbols/{0}.pdb/{1}/{0}.pdb' -OutFile '<somepath>\{0}.pdb' # File version {2}", pdbName, signaturePlusAge, fileVersion);
+                        finalCommand.AppendLine();
                     }
                 }
             }
 
             return finalCommand.ToString();
         }
-    }
 
-    /// <summary>
-    /// Helper class to store module name, start and end address
-    /// </summary>
-    class ModuleInfo
-    {
-        public string ModuleName;
-        public ulong BaseAddress;
-        public ulong EndAddress;
+        private bool disposedValue = false;
 
-        public override string ToString()
+        protected virtual void Dispose(bool disposing)
         {
-            return string.Format("{0} from {1:X} to {2:X}", ModuleName, BaseAddress, EndAddress);
-        }
-    }
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    rwLockCachedSymbols.Dispose();
+                }
 
-    /// <summary>
-    /// Wrapper class around DIA
-    /// </summary>
-    public class DiaUtil : IDisposable
-    {
-        public IDiaDataSource _IDiaDataSource;
-        public IDiaSession _IDiaSession;
-        public DiaUtil(string pdbName)
-        {
-            _IDiaDataSource = new DiaSource();
-            _IDiaDataSource.loadDataFromPdb(pdbName);
-            _IDiaDataSource.openSession(out _IDiaSession);
+                disposedValue = true;
+            }
         }
 
         public void Dispose()
         {
-            this.Dispose(true);
+            Dispose(true);
         }
-        public void Dispose(bool disposeAll)
-        {
-            Marshal.ReleaseComObject(_IDiaSession);
-            Marshal.ReleaseComObject(_IDiaDataSource);
-        }
-    }
-
-    /// <summary>
-    /// helper class for cases where we have XML output
-    /// </summary>
-    class StackWithCount
-    {
-        internal string Callstack;
-        internal string Resolvedstack;
-        internal int Count;
-    }
-
-    /// <summary>
-    /// Helper class which stores DLL export name and address (offset)
-    /// </summary>
-    public class ExportedSymbol
-    {
-        public string Name { get; set; }
-        public uint Address { get; set; }
-    }
-
-    /// <summary>
-    /// PE header's Image Export Directory
-    /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
-    public struct IMAGE_EXPORT_DIRECTORY
-    {
-        public uint Characteristics;
-        public uint TimeDateStamp;
-        public ushort MajorVersion;
-        public ushort MinorVersion;
-        public int Name;
-        public int Base;
-        public int NumberOfFunctions;
-        public int NumberOfNames;
-        public int AddressOfFunctions;
-        public int AddressOfNames;    
-        public int AddressOfOrdinals;                                 
     }
 }

--- a/Engine/StackWithCount.cs
+++ b/Engine/StackWithCount.cs
@@ -30,61 +30,16 @@
 //    to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.
 //</copyright>
 //------------------------------------------------------------------------------
+
 namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
 {
-    using System;
-
-    class Program
+    /// <summary>
+    /// helper class for cases where we have XML output
+    /// </summary>
+    class StackWithCount
     {
-        static void Main(string[] args)
-        {
-            if (!TestBlockResolution())
-                Console.WriteLine("FAIL: TestBlockResolution");
-            else
-                Console.WriteLine("PASS: TestBlockResolution");
-
-            if (!TestOrdinal())
-                Console.WriteLine("FAIL: TestOrdinal");
-            else
-                Console.WriteLine("PASS: TestOrdinal");
-
-        }
-
-        private static bool TestBlockResolution()
-        {
-            var csr = new StackResolver();
-            var ret = csr.ResolveCallstacks("Return Addr: 00007FF830D4CDA4 Module(KERNELBASE+000000000009CDA4)",
-                @"..\..\Tests\TestCases\TestBlockResolution",
-                false,
-                null,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "KERNELBASE!SignalObjectAndWait+147716";
-        }
-
-        private static bool TestOrdinal()
-        {
-            var csr = new StackResolver();
-            var dllPaths = new System.Collections.Generic.List<string>();
-            dllPaths.Add(@"..\..\Tests\TestCases\TestOrdinal");
-
-            var ret = csr.ResolveCallstacks("sqldk!Ordinal298+00000000000004A5",
-                @"..\..\Tests\TestCases\TestOrdinal",
-                false,
-                dllPaths,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false);
-
-            return ret.Trim() == "sqldk!SOS_Scheduler::SwitchContext+941";
-        }
+        internal string Callstack;
+        internal string Resolvedstack;
+        internal int Count;
     }
 }

--- a/Engine/ThreadParams.cs
+++ b/Engine/ThreadParams.cs
@@ -1,0 +1,53 @@
+﻿//------------------------------------------------------------------------------
+//<copyright company="Microsoft">
+//    The MIT License (MIT)
+//    
+//    Copyright (c) 2017 Microsoft
+//    
+//    Permission is hereby granted; free of charge; to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"); to deal
+//    in the Software without restriction; including without limitation the rights
+//    to use; copy; modify; merge; publish; distribute; sublicense; and/or sell
+//    copies of the Software; and to permit persons to whom the Software is
+//    furnished to do so; subject to the following conditions:
+//    
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//    
+//    THE SOFTWARE IS PROVIDED "AS IS"; WITHOUT WARRANTY OF ANY KIND; EXPRESS OR
+//    IMPLIED; INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY;
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM; DAMAGES OR OTHER
+//    LIABILITY; WHETHER IN AN ACTION OF CONTRACT; TORT OR OTHERWISE; ARISING FROM;
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
+//
+//    This sample code is not supported under any Microsoft standard support program or service. 
+//    The entire risk arising out of the use or performance of the sample scripts and documentation remains with you. 
+//    In no event shall Microsoft; its authors; or anyone else involved in the creation; production; or delivery of the scripts
+//    be liable for any damages whatsoever (including; without limitation; damages for loss of business profits;
+//    business interruption; loss of business information; or other pecuniary loss) arising out of the use of or inability
+//    to use the sample scripts or documentation; even if Microsoft has been advised of the possibility of such damages.
+//</copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
+{
+    using System.Collections.Generic;
+
+    internal class ThreadParams
+    {
+        internal int threadOrdinal;
+        internal List<StackWithCount> listOfCallStacks;
+        internal string symPath;
+        internal bool searchPDBsRecursively;
+        internal List<string> dllPaths;
+        internal bool searchDLLRecursively;
+        internal bool framesOnSingleLine;
+        internal bool includeSourceInfo;
+        internal bool relookupSource;
+        internal bool includeOffsets;
+        internal int numThreads;
+        internal bool cachePDB;
+    }
+}

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -40,9 +40,14 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                _resolver.Dispose();
+
+                if (components != null)
+                {
+                    components.Dispose();
+                }
             }
             base.Dispose(disposing);
         }
@@ -76,6 +81,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
             this.PDBPathPicker = new System.Windows.Forms.Button();
             this.BinaryPathPicker = new System.Windows.Forms.Button();
             this.BucketizeXEL = new System.Windows.Forms.CheckBox();
+            this.cachePDB = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // ResolveCallStackButton
@@ -110,8 +116,6 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
             // pdbRecurse
             // 
             this.pdbRecurse.AutoSize = true;
-            this.pdbRecurse.Checked = true;
-            this.pdbRecurse.CheckState = System.Windows.Forms.CheckState.Checked;
             this.pdbRecurse.Location = new System.Drawing.Point(479, 481);
             this.pdbRecurse.Margin = new System.Windows.Forms.Padding(2);
             this.pdbRecurse.Name = "pdbRecurse";
@@ -293,12 +297,24 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
             this.BucketizeXEL.Text = "Bucketize XEL?";
             this.BucketizeXEL.UseVisualStyleBackColor = true;
             // 
+            // cachePDB
+            // 
+            this.cachePDB.AutoSize = true;
+            this.cachePDB.Location = new System.Drawing.Point(1031, 512);
+            this.cachePDB.Margin = new System.Windows.Forms.Padding(2);
+            this.cachePDB.Name = "cachePDB";
+            this.cachePDB.Size = new System.Drawing.Size(109, 21);
+            this.cachePDB.TabIndex = 22;
+            this.cachePDB.Text = "Copy PDBs?";
+            this.cachePDB.UseVisualStyleBackColor = true;
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(1283, 542);
+            this.Controls.Add(this.cachePDB);
             this.Controls.Add(this.BucketizeXEL);
             this.Controls.Add(this.BinaryPathPicker);
             this.Controls.Add(this.PDBPathPicker);
@@ -350,6 +366,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
         private System.Windows.Forms.Button PDBPathPicker;
         private System.Windows.Forms.Button BinaryPathPicker;
         private System.Windows.Forms.CheckBox BucketizeXEL;
+        private System.Windows.Forms.CheckBox cachePDB;
     }
 }
 

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -78,7 +78,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver
                 FramesOnSingleLine.Checked,
                 IncludeLineNumbers.Checked,
                 RelookupSource.Checked,
-                includeOffsets.Checked
+                includeOffsets.Checked,
+                cachePDB.Checked
                 );
         }
 


### PR DESCRIPTION
* Cache RVA -> symbol lookups where possible
* Use dedicated threads for ensuring DIA objects are reused across calls
* Moved supporting classes into their own files
* Ensure Dispose() pattern is implemented and used correctly
* Optionally cache PDBs in %TEMP%\SymCache (useful when using UNC paths)