### PR TITLE
Update microsoft/setup-msbuild to 1.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout Code
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1
     - name: Restore NuGet Packages


### PR DESCRIPTION
This addresses a deprecation issue
(https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)